### PR TITLE
Add RockyLinux and AlmaLinux to operating systems list

### DIFF
--- a/webroot/model/schema-io500.json
+++ b/webroot/model/schema-io500.json
@@ -197,6 +197,8 @@
                     "SUSE Community",
                     "Ubuntu",
                     "CentOS",
+                    "RockyLinux",
+                    "AlmaLinux",
                     "other"
                 ],
                 "required":true,
@@ -1016,6 +1018,8 @@
                     "SUSE Community",
                     "Ubuntu",
                     "CentOS",
+                    "RockyLinux",
+                    "AlmaLinux",
                     "other"
                 ],
                 "db":"information_ds_operating_system,information_md_operating_system"


### PR DESCRIPTION
This closes #18 by adding RockyLinux and AlmaLinux to distribution list.