### PR TITLE
include checkboxes in submission confirmation step

### DIFF
--- a/config/Migrations/20260430120000_AddAcknowledgementsToSubmissions.php
+++ b/config/Migrations/20260430120000_AddAcknowledgementsToSubmissions.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+use Migrations\AbstractMigration;
+
+class AddAcknowledgementsToSubmissions extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('submissions')
+            ->addColumn('acknowledged_rules', 'boolean', [
+                'default' => false,
+                'null' => false,
+                'after' => 'information_production',
+            ])
+            ->addColumn('acknowledged_publication', 'boolean', [
+                'default' => false,
+                'null' => false,
+                'after' => 'acknowledged_rules',
+            ])
+            ->update();
+    }
+}

--- a/src/Controller/SubmissionsController.php
+++ b/src/Controller/SubmissionsController.php
@@ -124,7 +124,7 @@ class SubmissionsController extends AppController
 
             $submission = $this->Submissions->patchEntity($submission, $data);
 
-            if ($data['confirmation']) {
+            if (!empty($data['confirmation']) && !empty($data['acknowledged_rules']) && !empty($data['acknowledged_publication'])) {
                 $submission->status_id = 2;
             }
 

--- a/templates/Submissions/confirmation.php
+++ b/templates/Submissions/confirmation.php
@@ -58,6 +58,36 @@
         ?>
     </p>
 
+    <p>
+        <?php
+
+        echo $this->Form->control('acknowledged_rules',
+            [
+                'type' => 'checkbox',
+                'label' => [
+                    'escape' => false,
+                    'text' => 'I acknowledge that I have read and followed the '
+                        . '<a href="https://io500.org/rules/submission" target="_blank" rel="noopener noreferrer">IO500 submission rules</a>.',
+                ],
+                'required'
+            ]
+        );
+        ?>
+    </p>
+
+    <p>
+        <?php
+
+        echo $this->Form->control('acknowledged_publication',
+            [
+                'type' => 'checkbox',
+                'label' => 'I grant IO500 permission to publish and use these results for the official rankings and analysis.',
+                'required'
+            ]
+        );
+        ?>
+    </p>
+
     <div class="form-buttons">
         <?php
         echo $this->Form->button(


### PR DESCRIPTION
Include checkboxes in submission confirmation step:

<img width="1762" height="762" alt="image" src="https://github.com/user-attachments/assets/5a60b37a-cb25-49c0-9f76-7cd897810c1b" />

Also includes a migration to add those columns to the database.