### PR TITLE
builder: reorder IO500 and 10-NODE columns

### DIFF
--- a/templates/Submissions/build.php
+++ b/templates/Submissions/build.php
@@ -63,8 +63,8 @@
                     <th rowspan="2" class="tb"></th>
                     <th colspan="5" class="tb-center">Information</th>
                     <th colspan="3" class="tb-center">IO500</th>
-                    <th rowspan="2" class="tb-center"><?php echo $this->Paginator->sort('information_10_node_challenge', 'IO500') ?></th>
-                    <th rowspan="2" class="tb-center"><?php echo $this->Paginator->sort('include_in_io500', '10-NODE') ?></th>
+                    <th rowspan="2" class="tb-center"><?php echo $this->Paginator->sort('include_in_io500', 'IO500') ?></th>
+                    <th rowspan="2" class="tb-center"><?php echo $this->Paginator->sort('information_10_node_challenge', '10-NODE') ?></th>
                     <th rowspan="2" class="tb-center"><?php echo $this->Paginator->sort('information_production', 'PROD') ?></th>
                 </tr>
                 <tr>


### PR DESCRIPTION
Change the order in which the 10-NODE and IO500 fields are displayed, so that they match the column headers.

Closes: #11

<!---

**PLEASE NOTE:**

This is only a issue tracker for issues related to the CakePHP Application Skeleton.
For CakePHP Framework issues please use this [issue tracker](https://github.com/cakephp/cakephp/issues).

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) guidelines when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
